### PR TITLE
More accurately emulate native PHP session locking

### DIFF
--- a/src/Rairlie/LockingSession/EncryptedStore.php
+++ b/src/Rairlie/LockingSession/EncryptedStore.php
@@ -18,4 +18,31 @@ class EncryptedStore extends BaseEncryptedStore
         return $this->handler->needsRequest();
     }
 
+    /**
+     * Save the session data to storage.
+     *
+     * To more accurately emulate native php session locking, a session should only be written to after it has been started
+     * and should not be written to after it has been closed.
+     *
+     * @return void
+     */
+    public function save()
+    {
+        if ($this->started) {
+            parent::save();
+        }
+    }
+
+    /**
+     * Load the session data from the handler.
+     *
+     * To more accurately emulate native php when loading the session, existing data should not be merged into the loaded data.
+     *
+     * @return void
+     */
+    protected function loadSession()
+    {
+        $this->flush();
+        parent::loadSession();
+    }
 }

--- a/src/Rairlie/LockingSession/Store.php
+++ b/src/Rairlie/LockingSession/Store.php
@@ -18,4 +18,31 @@ class Store extends BaseStore
         return $this->handler->needsRequest();
     }
 
+    /**
+     * Save the session data to storage.
+     *
+     * To more accurately emulate native php session locking, a session should only be written to after it has been started
+     * and should not be written to after it has been closed.
+     *
+     * @return void
+     */
+    public function save()
+    {
+        if ($this->started) {
+            parent::save();
+        }
+    }
+
+    /**
+     * Load the session data from the handler.
+     *
+     * To more accurately emulate native php when loading the session, existing data should be flushed before loading data from session store.
+     *
+     * @return void
+     */
+    protected function loadSession()
+    {
+        $this->flush();
+        parent::loadSession();
+    }
 }


### PR DESCRIPTION
In the current version (1.1.1) it is still possible for the session lock to be bypassed.
The lock is released after the session is written to, but does not account for manually saving the session.

With the changes below you can now manually save the session (to emulate session_write_close()), release the lock and not worry about laravel writing over your session at request end. To protect session integrity the session should not be allowed to save if it has not been started (and thus not locked).