### PR TITLE
Update constraint to >= PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=7.0",
         "illuminate/session": ">=5.0"
     },
     "require-dev": {


### PR DESCRIPTION
This is added due to the null coalescing operator used on /Rairlie/LockingSession/SessionManager.php on line 20 - as it will cause PHP 5.X builds to fail.