### PR TITLE
Remove PHP 7.0 syntax

### DIFF
--- a/src/Rairlie/LockingSession/SessionManager.php
+++ b/src/Rairlie/LockingSession/SessionManager.php
@@ -17,7 +17,7 @@ class SessionManager extends BaseSessionManager
             return parent::buildSession($handler);
         }
 
-        $container = $this->container ?? $this->app;
+        $container = isset($this->container) ? $this->container : $this->app;
 
         if ($container['config']['session.encrypt']) {
             return new EncryptedStore(


### PR DESCRIPTION
https://github.com/rairlie/laravel-locking-session/blob/master/composer.json#L18 states package is compatible with PHP 5.5.9 and above. null coalesce `??` is only supported in PHP 7.0+ - https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op

Alternative is to bump `composer.json` requirements but that seemed unnecessary.

Relates to https://github.com/rairlie/laravel-locking-session/pull/21