### PR TITLE
Add Store constructor doc block

### DIFF
--- a/src/Rairlie/LockingSession/EncryptedStore.php
+++ b/src/Rairlie/LockingSession/EncryptedStore.php
@@ -1,16 +1,32 @@
 <?php
 namespace Rairlie\LockingSession;
 
+use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Session\EncryptedStore as BaseEncryptedStore;
+use SessionHandlerInterface;
 
 class EncryptedStore extends BaseEncryptedStore
 {
+    /**
+     * Create a new session instance.
+     *
+     * @param  string $name
+     * @param  SessionHandlerInterface $handler
+     * @param  EncrypterContract $encrypter
+     * @param  string|null $id
+     * @param  string|null $lockfileDir
+     * @return void
+     */
+    public function __construct(
+        $name,
+        SessionHandlerInterface $handler,
+        EncrypterContract $encrypter,
+        $id = null,
+        $lockfileDir = null
+    ) {
+        $lockingSessionHandler = new LockingSessionHandler($handler, $lockfileDir);
 
-    public function __construct($name, $realHandler, $id = null, $lockfileDir = null)
-    {
-        $lockingSessionHandler = new LockingSessionHandler($realHandler, $lockfileDir);
-
-        return parent::__construct($name, $lockingSessionHandler, $id);
+        parent::__construct($name, $lockingSessionHandler, $encrypter, $id);
     }
 
     public function handlerNeedsRequest()

--- a/src/Rairlie/LockingSession/EncryptedStore.php
+++ b/src/Rairlie/LockingSession/EncryptedStore.php
@@ -1,9 +1,7 @@
 <?php
 namespace Rairlie\LockingSession;
 
-use Illuminate\Contracts\Encryption\Encrypter as EncrypterContract;
 use Illuminate\Session\EncryptedStore as BaseEncryptedStore;
-use SessionHandlerInterface;
 
 class EncryptedStore extends BaseEncryptedStore
 {
@@ -11,22 +9,16 @@ class EncryptedStore extends BaseEncryptedStore
      * Create a new session instance.
      *
      * @param  string $name
-     * @param  SessionHandlerInterface $handler
-     * @param  EncrypterContract $encrypter
-     * @param  string|null $id
+     * @param  \SessionHandlerInterface $realHandler
+     * @param  \Illuminate\Contracts\Encryption\Encrypter $encrypter
      * @param  string|null $lockfileDir
      * @return void
      */
-    public function __construct(
-        $name,
-        SessionHandlerInterface $handler,
-        EncrypterContract $encrypter,
-        $id = null,
-        $lockfileDir = null
-    ) {
-        $lockingSessionHandler = new LockingSessionHandler($handler, $lockfileDir);
+    public function __construct($name, $realHandler, $encrypter, $lockfileDir = null)
+    {
+        $lockingSessionHandler = new LockingSessionHandler($realHandler, $lockfileDir);
 
-        parent::__construct($name, $lockingSessionHandler, $encrypter, $id);
+        parent::__construct($name, $lockingSessionHandler, $encrypter);
     }
 
     public function handlerNeedsRequest()

--- a/src/Rairlie/LockingSession/SessionManager.php
+++ b/src/Rairlie/LockingSession/SessionManager.php
@@ -24,6 +24,7 @@ class SessionManager extends BaseSessionManager
                 $container['config']['session.cookie'],
                 $handler,
                 $container['encrypter'],
+                null,
                 $container['config']['session.lockfile_dir']
             );
         } else {

--- a/src/Rairlie/LockingSession/SessionManager.php
+++ b/src/Rairlie/LockingSession/SessionManager.php
@@ -24,7 +24,6 @@ class SessionManager extends BaseSessionManager
                 $container['config']['session.cookie'],
                 $handler,
                 $container['encrypter'],
-                null,
                 $container['config']['session.lockfile_dir']
             );
         } else {

--- a/src/Rairlie/LockingSession/Store.php
+++ b/src/Rairlie/LockingSession/Store.php
@@ -10,14 +10,14 @@ class Store extends BaseStore
      * Create a new session instance.
      *
      * @param  string $name
-     * @param  SessionHandlerInterface $handler
+     * @param  SessionHandlerInterface $realHandler
      * @param  string|null $id
      * @param  string|null $lockfileDir
      * @return void
      */
-    public function __construct($name, SessionHandlerInterface $handler, $id = null, $lockfileDir = null)
+    public function __construct($name, $realHandler, $id = null, $lockfileDir = null)
     {
-        $lockingSessionHandler = new LockingSessionHandler($handler, $lockfileDir);
+        $lockingSessionHandler = new LockingSessionHandler($realHandler, $lockfileDir);
 
         parent::__construct($name, $lockingSessionHandler, $id);
     }

--- a/src/Rairlie/LockingSession/Store.php
+++ b/src/Rairlie/LockingSession/Store.php
@@ -2,15 +2,24 @@
 namespace Rairlie\LockingSession;
 
 use Illuminate\Session\Store as BaseStore;
+use SessionHandlerInterface;
 
 class Store extends BaseStore
 {
-
-    public function __construct($name, $realHandler, $id = null, $lockfileDir = null)
+    /**
+     * Create a new session instance.
+     *
+     * @param  string $name
+     * @param  SessionHandlerInterface $handler
+     * @param  string|null $id
+     * @param  string|null $lockfileDir
+     * @return void
+     */
+    public function __construct($name, SessionHandlerInterface $handler, $id = null, $lockfileDir = null)
     {
-        $lockingSessionHandler = new LockingSessionHandler($realHandler, $lockfileDir);
+        $lockingSessionHandler = new LockingSessionHandler($handler, $lockfileDir);
 
-        return parent::__construct($name, $lockingSessionHandler, $id);
+        parent::__construct($name, $lockingSessionHandler, $id);
     }
 
     public function handlerNeedsRequest()


### PR DESCRIPTION
The EncryptedStore constructor parameters are incorrect, or at the very least misleading. This results in warnings from phpstan and other static analysis software.

`EncryptedStore` constructor definition:
```php
public function __construct($name, $realHandler, $id = null, $lockfileDir = null)
```

Usage:
```php
return new EncryptedStore(
  $container['config']['session.cookie'],
  $handler,
  $container['encrypter'],
  $container['config']['session.lockfile_dir']
);
```

`$id` is being passed as `$container['encrypter']`

EncryptedStore constructor parameters haven't changed upstream since Laravel 5.5 https://github.com/laravel/framework/blob/5.5/src/Illuminate/Session/EncryptedStore.php#L27