### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/src/Rairlie/LockingSession/LockingSessionHandler.php
+++ b/src/Rairlie/LockingSession/LockingSessionHandler.php
@@ -19,16 +19,19 @@ class LockingSessionHandler implements SessionHandlerInterface, ExistenceAwareIn
         $this->lockfileDir = $lockfileDir;
     }
 
+    #[\ReturnTypeWillChange]
     public function close()
     {
         return $this->realHandler->close();
     }
 
+    #[\ReturnTypeWillChange]
     public function destroy($session_id)
     {
         return $this->realHandler->destroy($session_id);
     }
 
+    #[\ReturnTypeWillChange]
     public function gc($maxlifetime)
     {
         $dummy = new Lock('dummy', $this->lockfileDir);
@@ -37,11 +40,13 @@ class LockingSessionHandler implements SessionHandlerInterface, ExistenceAwareIn
         return $this->realHandler->gc($maxlifetime);
     }
 
+    #[\ReturnTypeWillChange]
     public function open($save_path, $name)
     {
         return $this->realHandler->open($save_path, $name);
     }
 
+    #[\ReturnTypeWillChange]
     public function read($session_id)
     {
         // Lock the session before reading and hold the lock
@@ -49,6 +54,7 @@ class LockingSessionHandler implements SessionHandlerInterface, ExistenceAwareIn
         return $this->realHandler->read($session_id);
     }
 
+    #[\ReturnTypeWillChange]
     public function write($session_id, $session_data)
     {
         $this->acquireLock($session_id);


### PR DESCRIPTION
```
Deprecated: Return type of Rairlie\LockingSession\LockingSessionHandler::open($save_path, $name) should either be compatible with SessionHandlerInterface::open(string $path, string $name): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /in/STlmC on line 34

Deprecated: Return type of Rairlie\LockingSession\LockingSessionHandler::close() should either be compatible with SessionHandlerInterface::close(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /in/STlmC on line 19

Deprecated: Return type of Rairlie\LockingSession\LockingSessionHandler::read($session_id) should either be compatible with SessionHandlerInterface::read(string $id): string|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /in/STlmC on line 39

Deprecated: Return type of Rairlie\LockingSession\LockingSessionHandler::write($session_id, $session_data) should either be compatible with SessionHandlerInterface::write(string $id, string $data): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /in/STlmC on line 45

Deprecated: Return type of Rairlie\LockingSession\LockingSessionHandler::destroy($session_id) should either be compatible with SessionHandlerInterface::destroy(string $id): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /in/STlmC on line 24

Deprecated: Return type of Rairlie\LockingSession\LockingSessionHandler::gc($maxlifetime) should either be compatible with SessionHandlerInterface::gc(int $max_lifetime): int|false, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /in/STlmC on line 29
```